### PR TITLE
Costs for shipping kits to teams is covered by SR

### DIFF
--- a/kickstart/kit/ship-courier.yaml
+++ b/kickstart/kit/ship-courier.yaml
@@ -9,7 +9,11 @@ milestone: $SRYYYY Kickstart
 description: >-
     Teams unable to make it to a Kickstart need their kits couriering to
     them.
-# TODO: clarify whether this is our responsibilty or that of the team.
+
+    Costs for this have historically been covered by SR.
+
+    We require teams to explicitly confirm their address by email before
+    dispatching a kit.
 
 dependencies:
     - kickstart/kit/allocate


### PR DESCRIPTION
Historically, SR have covered the costs for shipping kits to teams after kickstart.

Also note that we need to explicitly confirm teams' addresses before dispatching kits (eg. https://github.com/srobo/team-emails/blob/master/SR2019/2018-11-19-kit-disclaimer.md)