### PR TITLE
Support for GitHub import using PyGithub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.github-auth

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, Union
 
 import yaml
-from import_backends import FakeTracBackend, RealTracBackend
+from import_backends import FakeTracBackend, GitHubBackend, RealTracBackend
 from ticket_type import Ticket
 
 if TYPE_CHECKING:
@@ -105,17 +105,27 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('base', help="Root ticket to generate")
     parser.add_argument('year', help="SR year to generate for")
-    parser.add_argument(
+
+    backends_group = parser.add_mutually_exclusive_group()
+    backends_group.add_argument(
         '-t', '--trac-root',
         help="Base URL for the Trac installation",
         default=None,
     )
+    backends_group.add_argument(
+        '-g', '--github-repo',
+        help="GitHub repository name (e.g: srobo/tasks)",
+        default=None,
+    )
+
     return parser.parse_args()
 
 
 def main(arguments: argparse.Namespace) -> None:
     if arguments.trac_root is not None:
         backend: 'Backend' = RealTracBackend(arguments.trac_root)
+    elif arguments.github_repo is not None:
+        backend = GitHubBackend(arguments.github_repo)
     else:
         backend = FakeTracBackend()
 

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -176,7 +176,7 @@ class GitHubBackend:
 
     @staticmethod
     def _section(heading: str, body: str) -> str:
-        return f"\n\n### {heading}:\n\n{body}"
+        return f"\n\n### {heading}\n\n{body}"
 
     def _original_link(self, ticket: Ticket) -> str:
         url = urllib.parse.urljoin(

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -150,8 +150,13 @@ class GitHubBackend:
     def __init__(self, repo_name: str) -> None:
         self.github = github.Github(get_github_credential())
         self.repo = self.github.get_repo(repo_name)
-        self.milestones = {x.title: x for x in self.repo.get_milestones()}
-        labels = {x.name: x for x in self.repo.get_labels()}
+        self.milestones: Dict[str, github.Milestone.Milestone] = {
+            x.title: x for x in self.repo.get_milestones()
+        }
+
+        labels: Dict[str, github.Label.Label] = {
+            x.name: x for x in self.repo.get_labels()
+        }
 
         self._component_label_mapping = {
             k: labels[v] for k, v in self.COMPONENT_LABEL_MAPPING.items()

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -137,6 +137,7 @@ class GitHubBackend:
         'Rules': ['A: Game Rules'],
         'sysadmin': ['A: Software'],
         'Website': ['A: Software'],
+        'Tall Ship': ['Tall Ship'],
     }
 
     COMPONENT_PRIORITY_MAPPING: Dict[str, str] = {

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -220,7 +220,7 @@ class GitHubBackend:
             labels=self.labels(ticket),
         )
 
-        ticket_number: int = issue.id
+        ticket_number: int = issue.number
         self._known_titles[ticket_number] = ticket.summary
         return ticket_number
 

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -202,7 +202,7 @@ class GitHubBackend:
         try:
             return self.milestones[title]
         except KeyError:
-            print(f"Creating Milestong {title}")
+            print(f"Creating Milestone {title}")
             milestone = self.repo.create_milestone(title)
             self.milestones[title] = milestone
             return milestone

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -158,13 +158,18 @@ class GitHubBackend:
             x.name: x for x in self.repo.get_labels()
         }
 
-        self._component_label_mapping = {
-            k: [labels[x] for x in v]
-            for k, v in self.COMPONENT_LABEL_MAPPING.items()
-        }
-        self._component_priority_mapping = {
-            k: labels[v] for k, v in self.COMPONENT_PRIORITY_MAPPING.items()
-        }
+        try:
+            self._component_label_mapping = {
+                k: [labels[x] for x in v]
+                for k, v in self.COMPONENT_LABEL_MAPPING.items()
+            }
+            self._component_priority_mapping = {
+                k: labels[v] for k, v in self.COMPONENT_PRIORITY_MAPPING.items()
+            }
+        except KeyError as e:
+            raise ValueError(
+                f"Label {e} does not exist within {repo_name!r}",
+            ) from None
 
         self._known_titles: Dict[int, str] = {}
 

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -180,7 +180,7 @@ class GitHubBackend:
 
     def _original_link(self, ticket: Ticket) -> str:
         url = urllib.parse.urljoin(
-            self.repo.url,
+            'https://github.com/srobo/recurring-tasks/',
             f'blob/master/{ticket.original_name}.yaml',
         )
         return f"[{ticket.original_name}]({url})"

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -1,8 +1,10 @@
+import pathlib
 import textwrap
 import urllib.parse
 from getpass import getpass
 from typing import TYPE_CHECKING, Dict
 
+import github  # type: ignore
 from termcolor import cprint
 from ticket_type import Ticket
 
@@ -104,3 +106,80 @@ class RealTracBackend:
     def title(self, ticket_number: int) -> str:
         ticket_data = self._xml.ticket.get(ticket_number)
         return ticket_data[3]['summary']  # type: ignore
+
+
+def get_github_credential() -> str:
+    config_file = pathlib.Path(__file__).parent.parent / '.github-auth'
+
+    auth_token = None
+
+    if config_file.exists():
+        with config_file.open() as f:
+            auth_token = f.read()
+
+    if auth_token is None:
+        auth_token = getpass("GitHub Auth Token: ")
+
+        store = input("Store auth token? [y/N]: ")
+        if store in ('Y', 'y'):
+            with config_file.open(mode='w') as f:
+                f.write(auth_token)
+
+    return auth_token
+
+
+class GitHubBackend:
+    def __init__(self, repo_name: str) -> None:
+        self.github = github.Github(get_github_credential())
+        self.repo = self.github.get_repo(repo_name)
+        self.milestones = {x.title: x for x in self.repo.get_milestones()}
+
+        self._known_titles: Dict[int, str] = {}
+
+    @staticmethod
+    def _section(heading: str, body: str) -> str:
+        return f"\n\n### {heading}:\n\n{body}"
+
+    def _original_link(self, ticket: Ticket) -> str:
+        url = urllib.parse.urljoin(
+            self.repo.url,
+            f'blob/master/{ticket.original_name}.yaml',
+        )
+        return f"[{ticket.original_name}]({url})"
+
+    def description_text(self, ticket: Ticket) -> str:
+        text = ticket.description
+
+        text += self._section("Original", self._original_link(ticket))
+
+        if ticket.dependencies:
+            text += self._section("Dependencies", "\n".join(
+                f" * #{dep} {self.title(dep)}".rstrip()
+                for dep in sorted(ticket.dependencies)
+            ))
+
+        return text.strip()
+
+    def get_or_create_milestone(self, title: str) -> github.Milestone:
+        try:
+            return self.milestones[title]
+        except KeyError:
+            print(f"Creating Milestong {title}")
+            milestone = self.repo.create_milestone(title)
+            self.milestones[title] = milestone
+            return milestone
+
+    def submit(self, ticket: Ticket) -> int:
+        issue = self.repo.create_issue(
+            ticket.summary,
+            self.description_text(ticket),
+            milestone=self.get_or_create_milestone(ticket.milestone),
+            # TODO: priority & component
+        )
+
+        ticket_number: int = issue.id
+        self._known_titles[ticket_number] = ticket.summary
+        return ticket_number
+
+    def title(self, ticket_number: int) -> str:
+        return self._known_titles.get(ticket_number, '')

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -159,7 +159,8 @@ class GitHubBackend:
         }
 
         self._component_label_mapping = {
-            k: labels[v] for k, v in self.COMPONENT_LABEL_MAPPING.items()
+            k: [labels[x] for x in v]
+            for k, v in self.COMPONENT_LABEL_MAPPING.items()
         }
         self._component_priority_mapping = {
             k: labels[v] for k, v in self.COMPONENT_PRIORITY_MAPPING.items()

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -195,7 +195,7 @@ class GitHubBackend:
             self.milestones[title] = milestone
             return milestone
 
-    def labels(self, ticket: Ticket) -> List[github.Label]:
+    def labels(self, ticket: Ticket) -> List[github.Label.Label]:
         labels = [self._component_priority_mapping[ticket.priority]]
         labels += self._component_label_mapping[ticket.component]
         return labels

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 # Versions pinned for sanity, not because we have specific dependencies.
+PyGithub==1.43.8
 PyYAML==5.1.2
 termcolor==1.1.0


### PR DESCRIPTION
Adds a new GitHub backend.

Example import at https://github.com/PeterJCLaw/test/issues, generated via:
`./scripts/import.py -g PeterJCLaw/test test/main 1066`

This will unblock https://github.com/srobo/competition-team-minutes/issues/107.