### PR TITLE
Record imported tasks as we go

### DIFF
--- a/scripts/element_tracking.py
+++ b/scripts/element_tracking.py
@@ -18,8 +18,10 @@ class ElementsCache:
         self.cache_path = cache_path
         self.elements: Dict[str, int] = {}
 
-        if cache_path.exists():
+        try:
             self.elements = json.loads(cache_path.read_text())
+        except IOError:
+            pass
 
     def __enter__(self) -> Dict[str, int]:
         return self.elements

--- a/scripts/element_tracking.py
+++ b/scripts/element_tracking.py
@@ -1,0 +1,37 @@
+import contextlib
+from typing import Callable, Iterator, MutableMapping, Optional, Set
+
+
+class ElementsInProgress:
+    """
+    Keep track of the tasks as they're being imported.
+
+    This checks for cyclic dependencies and provides a way to consume existing
+    mappings of tasks that are known to be equivalent to those in this repo.
+    """
+
+    def __init__(self, known_elements: Optional[MutableMapping[str, int]]) -> None:
+        self.known_elements = known_elements or {}
+        self._current: Set[str] = set()
+
+    def get(self, key: str) -> Optional[int]:
+        if key in self._current:
+            raise RuntimeError(f"Cyclic dependency on {key}")
+
+        return self.known_elements.get(key)
+
+    @contextlib.contextmanager
+    def process(self, key: str) -> Iterator[Callable[[int], None]]:
+        if key in self._current:
+            raise RuntimeError(
+                f"Re-entrant processing not supported (attempted {key})",
+            )
+
+        def done(x: int) -> None:
+            self.known_elements[key] = x
+
+        self._current.add(key)
+        try:
+            yield done
+        finally:
+            self._current.remove(key)

--- a/scripts/element_tracking.py
+++ b/scripts/element_tracking.py
@@ -1,5 +1,36 @@
 import contextlib
-from typing import Callable, Iterator, MutableMapping, Optional, Set
+import json
+from pathlib import Path
+from types import TracebackType
+from typing import (
+    Callable,
+    Dict,
+    Iterator,
+    MutableMapping,
+    Optional,
+    Set,
+    Type,
+)
+
+
+class ElementsCache:
+    def __init__(self, cache_path: Path) -> None:
+        self.cache_path = cache_path
+        self.elements: Dict[str, int] = {}
+
+        if cache_path.exists():
+            self.elements = json.loads(cache_path.read_text())
+
+    def __enter__(self) -> Dict[str, int]:
+        return self.elements
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.cache_path.write_text(json.dumps(self.elements))
 
 
 class ElementsInProgress:

--- a/scripts/element_tracking.py
+++ b/scripts/element_tracking.py
@@ -30,7 +30,7 @@ class ElementsCache:
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
-        self.cache_path.write_text(json.dumps(self.elements))
+        self.cache_path.write_text(json.dumps(self.elements, sort_keys=True, indent=2))
 
 
 class ElementsInProgress:

--- a/scripts/element_tracking.py
+++ b/scripts/element_tracking.py
@@ -14,6 +14,15 @@ from typing import (
 
 
 class ElementsCache:
+    """
+    Load and cache the tasks that have been created in a file.
+
+    Use like:
+    ```
+    with ElementsCache(Path('cache.json')) as elements:
+        elements['key'] = 14
+    """
+
     def __init__(self, cache_path: Path) -> None:
         self.cache_path = cache_path
         self.elements: Dict[str, int] = {}
@@ -23,7 +32,7 @@ class ElementsCache:
         except IOError:
             pass
 
-    def __enter__(self) -> Dict[str, int]:
+    def __enter__(self) -> MutableMapping[str, int]:
         return self.elements
 
     def __exit__(

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -3,7 +3,7 @@
 import argparse
 import contextlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, MutableMapping, Optional
+from typing import TYPE_CHECKING, Callable, MutableMapping, Optional
 
 import yaml
 from element_tracking import ElementsCache, ElementsInProgress
@@ -156,11 +156,11 @@ def main(arguments: argparse.Namespace) -> None:
 
     with contextlib.ExitStack() as stack:
         if arguments.cache:
-            elements: Optional[Dict[str, int]] = stack.enter_context(
+            elements: MutableMapping[str, int] = stack.enter_context(
                 ElementsCache(arguments.cache),
             )
         else:
-            elements = None
+            elements = {}
 
         add(arguments.base, backend, arguments.year, known_elements=elements)
 


### PR DESCRIPTION
This provides a mechanism to record the tasks as they're imported and cache them out to a JSON file.
(Aside: it might have been nice to use [`shelve`](https://docs.python.org/3.8/library/shelve.html) rather than `json`, but this is now written and tested)

There's no support yet for pulling from an existing partially pre-populated import target, however adding that should be fairly straightforward.

I've manually tested this by partially importing into https://github.com/PeterJCLaw/test/. https://github.com/PeterJCLaw/test/issues/641, https://github.com/PeterJCLaw/test/issues/640 and https://github.com/PeterJCLaw/test/issues/639 were imported then the importer killed via `Ctrl+C`. The remaining tickets were imported over the course of a number of subsequent process runs (with more `Ctrl+C` to keep them short).