### PR TITLE
Change "crop" to "trim" for livestream

### DIFF
--- a/comp/livestream/crop-vod.yaml
+++ b/comp/livestream/crop-vod.yaml
@@ -1,4 +1,4 @@
-summary: Crop the live stream VOD (Video on Demand)
+summary: Trim the live stream VOD (Video on Demand)
 
 priority: minor
 
@@ -7,7 +7,7 @@ component: Competition
 milestone: $SRYYYY Competition Cleanup
 
 description: >-
-  The live stream VOD should be cropped to remove the start and end of the
+  The live stream VOD should be trimmed to remove the start and end of the
   competition.
 
 dependencies:


### PR DESCRIPTION
YouTube uses the term "trim" for cutting off the start and end. I think "crop" implies changing the field of view