### PR TITLE
Add area owners to all recurring tasks

### DIFF
--- a/comp/announce.yaml
+++ b/comp/announce.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The competition needs fanfare so that people know when & where it will
   happen. The following things should happen:

--- a/comp/appoint-safeguarding-officers.yaml
+++ b/comp/appoint-safeguarding-officers.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
     Safeguarding officers need to be appointed, by the Safeguarding Lead, as per the safeguarding policy.

--- a/comp/arena/acquire-screens.yaml
+++ b/comp/arena/acquire-screens.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We do not have enough screens to cover everything, so we may need to hire
   more.

--- a/comp/arena/barriers.yaml
+++ b/comp/arena/barriers.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     Since SR2015 we have used short wood-only walls for the actual arenas
     and had separate crowd barriers around the arena area (including the

--- a/comp/arena/batteries.yaml
+++ b/comp/arena/batteries.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   We should have a supply of charged batteries in the staging area next to the
   arena so that teams on their way into matches don't need to go to helpdesk to

--- a/comp/arena/build.yaml
+++ b/comp/arena/build.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     Build some arenas for the games.
 

--- a/comp/arena/carpet.yaml
+++ b/comp/arena/carpet.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     We currently use carpet as the flooring of the arenas. Usually the
     venue doesn't have an equivalent flooring underneath the arena

--- a/comp/arena/fire-extinguishers.yaml
+++ b/comp/arena/fire-extinguishers.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition Day
 
+area-owner: health-safety
+
 description: >-
   At least one powder fire extinguisher should be placed within easy reach next
   to each arena in case of LiPo fires.

--- a/comp/arena/labels.yaml
+++ b/comp/arena/labels.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     Since we have more than one arena we want a way to tell which is
     which. One possible mechanism is to colour-code them, though having

--- a/comp/arena/main.yaml
+++ b/comp/arena/main.yaml
@@ -7,6 +7,8 @@ milestone: $SRYYYY Competition Day
 description: >-
     Central ticket for hanging arena things from.
 
+area-owner: event-logistics
+
 dependencies:
   - comp/arena/build
   - comp/arena/barriers

--- a/comp/arena/music.yaml
+++ b/comp/arena/music.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
     During matches we want music to be played into the arena.
 

--- a/comp/arena/network.yaml
+++ b/comp/arena/network.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The arena needs network for the screens and score entry.
 

--- a/comp/arena/non-arena-display-screens.yaml
+++ b/comp/arena/non-arena-display-screens.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   Throughout the venue we typically have a number of general information screens
   which show the schedule of matches, state of the league, etc. We need to organise

--- a/comp/arena/power.yaml
+++ b/comp/arena/power.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   The arenas need power for displays.
 

--- a/comp/arena/reset-checklist.yaml
+++ b/comp/arena/reset-checklist.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We should create a checklist for the marshals so they know what needs
   to ebe done between matches to reset the arena. This should be as

--- a/comp/arena/screens-drivers.yaml
+++ b/comp/arena/screens-drivers.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: |
     We have screens around the arena to display live information, these
     need something to drive them.

--- a/comp/arena/screens-stands.yaml
+++ b/comp/arena/screens-stands.yaml
@@ -6,5 +6,7 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   The arena screens need to be mounted on something to be visible.

--- a/comp/arena/screens.yaml
+++ b/comp/arena/screens.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We have screens around the arena to display live information, these
   need putting up.

--- a/comp/arena/staging-area.yaml
+++ b/comp/arena/staging-area.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: |
     Build the staging area for the arenas, where the teams will attach
     and remove the robot-flags and competition-mode USB keys.

--- a/comp/arena/tape.yaml
+++ b/comp/arena/tape.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     For the competition we will need vast quantities of tape:
     - white

--- a/comp/arena/tools.yaml
+++ b/comp/arena/tools.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     For arena construction we'll likely need various tools. Many of these we
     probably have, however we should put together a list of what we think we'll

--- a/comp/cleanup.yaml
+++ b/comp/cleanup.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: event-logistics
+
 description: >-
   Root ticket for all cleanup related items
 

--- a/comp/computer-hardware.yaml
+++ b/comp/computer-hardware.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: |
     We will need a large number of computers for the competition. This
     ticket serves as a central place which records everything other than

--- a/comp/day-schedule.yaml
+++ b/comp/day-schedule.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We need a list of what is happening at what times on both days of the
   competition (tinker time, lunch, league etc).

--- a/comp/feedback/gather-team-feedback.yaml
+++ b/comp/feedback/gather-team-feedback.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: teams
+
 description: >-
   Send to everyone who was signed up for $SRYYYY.
 

--- a/comp/feedback/gather-volunteer-feedback.yaml
+++ b/comp/feedback/gather-volunteer-feedback.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   Send to everyone who was signed up for $SRYYYY.
 

--- a/comp/feedback/post-competition-reports.yaml
+++ b/comp/feedback/post-competition-reports.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: committee
+
 description: >-
   We should give a report on the $SRYYYY competition cycle and details of the
   event to the trustees once everything from the event has been sorted out.

--- a/comp/flyers.yaml
+++ b/comp/flyers.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The primary target of these flyers are invited guests (both of SR and of the
   teams), who may not know very much about either Student Robotics or the game

--- a/comp/game/desk-lamp.yaml
+++ b/comp/game/desk-lamp.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   Having a desk lamp on the score-entry desk can be useful if it is
   located somewhere that may not have enough light otherwise. This is

--- a/comp/game/finals-music.yaml
+++ b/comp/game/finals-music.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
     We generally use a bespoke cut of various songs for the finals tracks, to
     build tension, ensure the music is dramatic enough, and is timed perfectly,

--- a/comp/game/knockout-design.yaml
+++ b/comp/game/knockout-design.yaml
@@ -6,5 +6,7 @@ component: Rules
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
     We need to specify the structure of the knockouts.

--- a/comp/game/knockout.yaml
+++ b/comp/game/knockout.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
   The knockout matches need to happen.
 

--- a/comp/game/league-schedule.yaml
+++ b/comp/game/league-schedule.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The schedule for the league matches needs to be generated.

--- a/comp/game/league.yaml
+++ b/comp/game/league.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
   The league matches which determine knockout seeds and the winner of
   the rookie award need to take place.

--- a/comp/game/main.yaml
+++ b/comp/game/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
   We need to run all the matches at the competition.
 

--- a/comp/game/markers.yaml
+++ b/comp/game/markers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   The arena (and, possibly, things inside it) is marked with AprilTag
   markers, which need printing off in advance.

--- a/comp/game/props.yaml
+++ b/comp/game/props.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     We need to prepare the things that will go in the arena.
     See this year's [rulebook](https://studentrobotics.org/docs/resources/$YYYY/rulebook.pdf)

--- a/comp/game/robot-flag-mounts.yaml
+++ b/comp/game/robot-flag-mounts.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   During matches robots are given coloured flags so that the audience know which
   robot is from which scoring zone.

--- a/comp/game/robot-flags.yaml
+++ b/comp/game/robot-flags.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   During matches robots are given coloured flags so that the audience know which
   robot is from which scoring zone.

--- a/comp/game/score-entry.yaml
+++ b/comp/game/score-entry.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We need a data entry system for converting from the score entry forms
   to the YAML file format.

--- a/comp/game/score-format.yaml
+++ b/comp/game/score-format.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The format for the game data YAML files which record match outcomes
   needs to be designed.

--- a/comp/game/score-forms-print.yaml
+++ b/comp/game/score-forms-print.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
    The actual sheets to be filled in need to be printed.
 

--- a/comp/game/score-forms.yaml
+++ b/comp/game/score-forms.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   Score entry forms for use by marshals in the arenas need to be
   designed.

--- a/comp/game/score-script.yaml
+++ b/comp/game/score-script.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The scoring script provides automatic computation of the scores based on the
   data input from the score sheets.

--- a/comp/game/scoring-stationery.yaml
+++ b/comp/game/scoring-stationery.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   Once printed we need something to store the score entry forms in
   (as there will be a couple of hundred sheets).

--- a/comp/game/scoring.yaml
+++ b/comp/game/scoring.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We need to be able to score matches.
 

--- a/comp/game/shepherding.yaml
+++ b/comp/game/shepherding.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The situation for shepherding teams to their matches needs to be
   organised.

--- a/comp/game/usbs.yaml
+++ b/comp/game/usbs.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   During matches the robots need a mechanism to know which corner they're
   in and to ensure that they can only see the proper libkoki markers.

--- a/comp/kit-handback.yaml
+++ b/comp/kit-handback.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   Arrangements must be made for the kit handback procedure at the end of
   the competition.

--- a/comp/kit-loans.yaml
+++ b/comp/kit-loans.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   We often let teams keep kit after the competition we should plan if
   and how we are going to do this.

--- a/comp/kit-testing-equipment.yaml
+++ b/comp/kit-testing-equipment.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
     While we should be happy to replace kit at the competition it is also
     useful to be able to quickly diagnose common issues wit the kit, in

--- a/comp/livestream/configure-scenes.yaml
+++ b/comp/livestream/configure-scenes.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: livestream
+
 description: >-
   The livestream requires a number of different scenes and views, made up of
   static images, video feeds, overlays etc.

--- a/comp/livestream/crop-vod.yaml
+++ b/comp/livestream/crop-vod.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: livestream
+
 description: >-
   The live stream VOD should be trimmed to remove the start and end of the
   competition.

--- a/comp/livestream/hardware.yaml
+++ b/comp/livestream/hardware.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: livestream
+
 description: >-
   This ticket relates to providing the actual machine that will be
   used for the livestream.

--- a/comp/livestream/local.yaml
+++ b/comp/livestream/local.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: livestream
+
 description: >-
   We should ensure the live stream of the competition is viewable within
   the venue. This enables everyone to see matches without actually being

--- a/comp/livestream/main.yaml
+++ b/comp/livestream/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: livestream
+
 description: >-
   We should have a live stream of the competition.
 

--- a/comp/livestream/plan-video-feeds.yaml
+++ b/comp/livestream/plan-video-feeds.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: livestream
+
 description: >-
   The livestream will need to have a few different camera feeds to show different parts of the venue
 

--- a/comp/livestream/training.yaml
+++ b/comp/livestream/training.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: livestream
+
 description: >-
   Volunteers who are assigned to run the livestream should be
   trained how the system works, and how the event will be run.

--- a/comp/main.yaml
+++ b/comp/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: committee
+
 description: >-
     We need to have the $SRYYYY competition event.
 

--- a/comp/media-consent/email.yaml
+++ b/comp/media-consent/email.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     Teams need to be sent an email with a link to the media consent form and instructions on how to return them to us.
 

--- a/comp/media-consent/form-update.yaml
+++ b/comp/media-consent/form-update.yaml
@@ -6,5 +6,7 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     The media consent form needs publishing for $SRYYYY.

--- a/comp/media-consent/main.yaml
+++ b/comp/media-consent/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     We need media consent from everyone at the competition.
 

--- a/comp/media-consent/spares.yaml
+++ b/comp/media-consent/spares.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   Those coming just to watch the competition still need to sign media
   consent forms. We need a stack of spares to be held at reception.

--- a/comp/media-consent/tickets.yaml
+++ b/comp/media-consent/tickets.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   We need to organise the issuing of tickets for the competition.

--- a/comp/ops/compstate.yaml
+++ b/comp/ops/compstate.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
     The competition software has state about the competition which is used to
     drive the matches, live displays of scores (etc.) both within the venue on

--- a/comp/ops/deploy-compbox.yaml
+++ b/comp/ops/deploy-compbox.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
     The compbox VM will need deploying onto the host machine and ensuring
     that it works.

--- a/comp/ops/deploy-score-entry.yaml
+++ b/comp/ops/deploy-score-entry.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
     The machine which will be used for score entry need setting up.
     At least one of these is expected to be a permanent machine placement.

--- a/comp/ops/deploy.yaml
+++ b/comp/ops/deploy.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
     Ops needs a table and network connection to work from. It should be
     located somewhere protected from the competitors, but vaguely near

--- a/comp/ops/main.yaml
+++ b/comp/ops/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
     We need ops.
 

--- a/comp/ops/plan-tech-desk.yaml
+++ b/comp/ops/plan-tech-desk.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   Ensure we have enough table top space, power and networking for all necessary equipment at the tech desk.
 

--- a/comp/ops/prepare-compbox.yaml
+++ b/comp/ops/prepare-compbox.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
     We have a Raspberry Pi 3 (part code `srL1CX`) which is typically used
     as the compbox.

--- a/comp/ops/score-entry-hardware.yaml
+++ b/comp/ops/score-entry-hardware.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
     This ticket relates to providing the actual machine that will be
     used by the score entry volunteers.

--- a/comp/ops/teams-import.yaml
+++ b/comp/ops/teams-import.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
      We need to run the teams import into the compstate as part of the
      setup so that it's got the latest team images.

--- a/comp/photos/blueshirts.yaml
+++ b/comp/photos/blueshirts.yaml
@@ -6,5 +6,7 @@ component: Media
 
 milestone: $SRYYYY Competition Day
 
+area-owner: media-press
+
 description: >-
     We should take a group photograph of all the Blueshrits.

--- a/comp/photos/everyone.yaml
+++ b/comp/photos/everyone.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition Day
 
+area-owner: media-press
+
 description: >-
     We should take a group photograph of all the teams and their robots.
 

--- a/comp/photos/main.yaml
+++ b/comp/photos/main.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition Day
 
+area-owner: media-press
+
 description: >-
     Photos make for good publicity material and allow teams to show off
     their dress and their robot.

--- a/comp/photos/teams.yaml
+++ b/comp/photos/teams.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition Day
 
+area-owner: media-press
+
 description: >-
     We should take photographs individually of all the teams and their
     robots. This allows them to show off their team image as well as

--- a/comp/pits/battery-charging.yaml
+++ b/comp/pits/battery-charging.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   There are many batteries that need charging and we need to set up the
   charging station. This should be somewhere safe to charge the batteries

--- a/comp/pits/helpdesk/expert-list.yaml
+++ b/comp/pits/helpdesk/expert-list.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: mentoring
+
 description: >-
   If there is a problem at helpdesk, that those on helpdesk cannot solve, they need to know who to escalate to.
 

--- a/comp/pits/helpdesk/main.yaml
+++ b/comp/pits/helpdesk/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: mentoring
+
 description: >-
   Helpdesk is the single-point-of-contact for teams to get help with
   their robots. We need to plan who will run this on the day as well

--- a/comp/pits/helpdesk/print-documents.yaml
+++ b/comp/pits/helpdesk/print-documents.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: mentoring
+
 description: >-
   Helpdesk will need a number of documents
 

--- a/comp/pits/helpdesk/spare-kit.yaml
+++ b/comp/pits/helpdesk/spare-kit.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   If kit breaks at the competition for teams, we should be prepared to
   replace it at high speed. For that we will need hot spares.

--- a/comp/pits/labels.yaml
+++ b/comp/pits/labels.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     Each pit should have a large visible label so it's clear who is where.
     While maps help, having a label makes things easier for shepherds

--- a/comp/pits/layout.yaml
+++ b/comp/pits/layout.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   The layout of team pits in the venue needs to be worked out. There are
   constraints such as keeping teams under the same teacher close

--- a/comp/pits/main.yaml
+++ b/comp/pits/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   Teams need team pits to work in, and these need setting up.
 

--- a/comp/pits/network.yaml
+++ b/comp/pits/network.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   Teams need access to the internet to use the IDE and get at
   documentation. We therefore need network access in all the team pits.

--- a/comp/pits/overnight-loans.yaml
+++ b/comp/pits/overnight-loans.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: kit
+
 description: >-
   Many teams will want to take their kits home with them overnight at
   the competition, in order to work on them. We usually require these

--- a/comp/pits/power-tools.yaml
+++ b/comp/pits/power-tools.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
   Rather than letting teams use power tools in their team pits, we ask
   them to go to a separate area.

--- a/comp/pits/power.yaml
+++ b/comp/pits/power.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   All the team pits and related areas need power provided.
 

--- a/comp/pits/rollout.yaml
+++ b/comp/pits/rollout.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
 
 dependencies:

--- a/comp/pits/rules.yaml
+++ b/comp/pits/rules.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   We'll want a collection of rules for the competitors on the day.
   In the past this has included rules about where power tools and paint

--- a/comp/pits/tables.yaml
+++ b/comp/pits/tables.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We're not sure how many chairs and tables will make a pit yet.
   This will change based on venue.

--- a/comp/pre-comp-storage-trip.yaml
+++ b/comp/pre-comp-storage-trip.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: event-logistics
+
 description: >-
   We'll need to visit storage at some point before the competition, to check quantities of consumables
   (tape etc.) and to pick up other things which need checking/fixing/updating etc.

--- a/comp/prepare-news-afterwards.yaml
+++ b/comp/prepare-news-afterwards.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   After the competition we want to have a news article which describes how the
   event went, which teams won, etc.

--- a/comp/press/invite-press.yaml
+++ b/comp/press/invite-press.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   We should invite some press to the competition.

--- a/comp/press/invite-sponsors.yaml
+++ b/comp/press/invite-sponsors.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   We should send out invitations to various people from both our current and any
   prospective sponsoring organisations to come along to the competition.

--- a/comp/print-flyers.yaml
+++ b/comp/print-flyers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 dependencies:
     - comp/flyers
 

--- a/comp/printing.yaml
+++ b/comp/printing.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
      We need various stuff printing before we get to the venue.
 

--- a/comp/prizes/ceremony.yaml
+++ b/comp/prizes/ceremony.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   At the end of the competition we want to give out some prizes. We need to plan
   how we will transition from the finals, through any speeches and run the

--- a/comp/prizes/certificate-design.yaml
+++ b/comp/prizes/certificate-design.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   The certificates need to be designed.

--- a/comp/prizes/certificates.yaml
+++ b/comp/prizes/certificates.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   Certificates need distribution to members of the winning teams.
 

--- a/comp/prizes/committee-award.yaml
+++ b/comp/prizes/committee-award.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The winner of the committee award needs deciding.

--- a/comp/prizes/edible-prizes.yaml
+++ b/comp/prizes/edible-prizes.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   Some awards have edible prizes for distribution at the prize ceremony:
   these need purchasing.

--- a/comp/prizes/envelopes.yaml
+++ b/comp/prizes/envelopes.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
     We like to put the results on pieces of card, inside envelopes, to add a
     sense of drama to the prize ceremony. We need to source that card and

--- a/comp/prizes/first-movement.yaml
+++ b/comp/prizes/first-movement.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The forums need to be searched for who won the first movement award.

--- a/comp/prizes/main.yaml
+++ b/comp/prizes/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   The prizes for the various award categories need organisation.
 

--- a/comp/prizes/position-awards.yaml
+++ b/comp/prizes/position-awards.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The winners of the 1st, 2nd and 3rd places as well as the rookie award
   need to be established beyond reasonable doubt.

--- a/comp/prizes/rehearsal.yaml
+++ b/comp/prizes/rehearsal.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: production
+
 description: >-
   At the end of the competition we want to give out some prizes. We need to
   rehearse how we will transition from the finals, through any speeches and run

--- a/comp/prizes/speaker.yaml
+++ b/comp/prizes/speaker.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     This should be someone involved in technology and who the competitors
     can recognise as such. Extra points if the person is actually famous.

--- a/comp/prizes/team-image.yaml
+++ b/comp/prizes/team-image.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The winners of the team and robot image awards need to be decided.

--- a/comp/prizes/trophies.yaml
+++ b/comp/prizes/trophies.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   Some awards involve trophies being given to the winning teams. The
   trophies need purchasing.

--- a/comp/prizes/web-presence.yaml
+++ b/comp/prizes/web-presence.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The online presence award is put to a vote of the community. This
   needs to happen before the competition.

--- a/comp/publish-news-afterwards.yaml
+++ b/comp/publish-news-afterwards.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: media-press
+
 description: >-
   After the competition we want to have a news article which describes how the
   event went, which teams won, etc. This should have been mostly written before

--- a/comp/reception/hardware.yaml
+++ b/comp/reception/hardware.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     We currently use laptops equipped with webcams to handle entry
     validation on the day. We need to ensure that there are enough

--- a/comp/reception/main.yaml
+++ b/comp/reception/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   This is needed for entry control. Everyone (competitors, team-leaders,
   blueshirts and guests) who wants to come in must have a ticket or a

--- a/comp/reception/network.yaml
+++ b/comp/reception/network.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: event-logistics
+
 description: >-
     The reception desk(s) need an internet connection for computers
     running the admission software.

--- a/comp/reception/power.yaml
+++ b/comp/reception/power.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: event-logistics
+
 description: >-
     The reception desk needs power for computers running the admission
     software.

--- a/comp/reception/tablecloths.yaml
+++ b/comp/reception/tablecloths.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The reception desks are among the first things which anyone will see
   when arriving at the competition. So that we give a good impression,

--- a/comp/safety/check-robots.yaml
+++ b/comp/safety/check-robots.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: health-safety
+
 description: >-
     We need to inspect all the robots to ensure they are safe.
 

--- a/comp/safety/ensure-fire-extinguishers-are-present.yaml
+++ b/comp/safety/ensure-fire-extinguishers-are-present.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
 
   We should ensure that venue has suffucient fire extinguishers for our

--- a/comp/safety/first-aid.yaml
+++ b/comp/safety/first-aid.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
   We need to provide first aid coverage at the competition for both main
   days.

--- a/comp/safety/high-vis.yaml
+++ b/comp/safety/high-vis.yaml
@@ -4,6 +4,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
     At the competition we use high-vis jackets to signify that a robot
     has passed the safety checks and which member of the team is responsible

--- a/comp/safety/incident-plan.yaml
+++ b/comp/safety/incident-plan.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
   We should ensure that our incident response plans are current &
   applicable to the selected venue; we should update them as needed.

--- a/comp/safety/incident-record.yaml
+++ b/comp/safety/incident-record.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
   We need a means to record and store details of an incident or near-
   miss occurring. At bare minimum this needs to store what happened and

--- a/comp/safety/main.yaml
+++ b/comp/safety/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
     The $SRYYYY competition event must be safe.
 

--- a/comp/safety/risk-assessments.yaml
+++ b/comp/safety/risk-assessments.yaml
@@ -6,5 +6,7 @@ priority: critical
 
 component: Competition
 
+area-owner: health-safety
+
 description: >-
     The risk assessment for the competition needs updating for $SRYYYY and publishing to schools.

--- a/comp/safety/sad-battery-management.yaml
+++ b/comp/safety/sad-battery-management.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: health-safety
+
 description: >-
   We should have a plan for how to handle lipos which are deemed to be unusable.
   This is to cover the handling of the lipos at the event, not the disposal

--- a/comp/setup-plan.yaml
+++ b/comp/setup-plan.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Prep
 
+area-owner: event-logistics
+
 description: >-
   We need to plan tasks for the setup days
 

--- a/comp/setup.yaml
+++ b/comp/setup.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: event-logistics
+
 description: >-
 
 dependencies:

--- a/comp/social-media.yaml
+++ b/comp/social-media.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     In addition to the task-specific social media related to the competition
     announcement and the news article afterwards we should ensure that our

--- a/comp/tear-down/destinations.yaml
+++ b/comp/tear-down/destinations.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We need a plan of what is going to be returned to where after the
   competition, ideally with in-venue holding areas identified for each

--- a/comp/tear-down/main.yaml
+++ b/comp/tear-down/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   Everything will need tearing down at the end of the competition.
 

--- a/comp/tinker-time.yaml
+++ b/comp/tinker-time.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
   On the morning of the first day, teams are given a chance to tinker with
   their robots in the arenas. We're going to use a whiteboard to schedule this.

--- a/comp/uprate-server.yaml
+++ b/comp/uprate-server.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: teams
+
 description: >-
     During week preceding and particularly over the competition weekend our
     competitor-services server gets a lot more load than it normally does.

--- a/comp/venue/arena-lighting.yaml
+++ b/comp/venue/arena-lighting.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We need lighting on the arenas.
 

--- a/comp/venue/book.yaml
+++ b/comp/venue/book.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     We need a venue for $SRYYYY.

--- a/comp/venue/cable-protectors.yaml
+++ b/comp/venue/cable-protectors.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     It's a bad idea to have loose cables trailing around on the floor.
     We should hire cable protectors to cover the cables anywhere necessary.

--- a/comp/venue/fire-plans.yaml
+++ b/comp/venue/fire-plans.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We need the venue's fire plans to organise the layout.

--- a/comp/venue/insurance.yaml
+++ b/comp/venue/insurance.yaml
@@ -6,5 +6,7 @@ milestone: $SRYYYY Competition
 
 component: Competition
 
+area-owner: event-logistics
+
 description: >-
     We need to be covered by public liability insurance at the competition.

--- a/comp/venue/layout-map.yaml
+++ b/comp/venue/layout-map.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We should have maps of the layout for reference. This should
   include maps with team locations.

--- a/comp/venue/layout.yaml
+++ b/comp/venue/layout.yaml
@@ -6,11 +6,13 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   This will need to specify where the arenas, team pits, reception,
   helpdesk and so forth are.
 
-  The outcome from this task should be an entry in https://github.com/srobo/comp-floorplans. 
+  The outcome from this task should be an entry in https://github.com/srobo/comp-floorplans.
 
 dependencies:
   - comp/venue/fire-plans

--- a/comp/venue/network.yaml
+++ b/comp/venue/network.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     This also requires that we have a pretty significant internet connection
     given the number of people that are coming and our video streaming

--- a/comp/venue/power.yaml
+++ b/comp/venue/power.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   For pretty much everything we do, we need power.

--- a/comp/venue/printer.yaml
+++ b/comp/venue/printer.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     In case we need to print out MCFs/game lists/whatever at high speed.

--- a/comp/venue/prs-ppl.yaml
+++ b/comp/venue/prs-ppl.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
     In order to play music at the competition we need a "TheMusicLicence"
     (which replaced the separat PRS & PPL licenese in 2018).

--- a/comp/venue/radios.yaml
+++ b/comp/venue/radios.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     We need to hire some radios and headsets.

--- a/comp/venue/signage.yaml
+++ b/comp/venue/signage.yaml
@@ -6,6 +6,8 @@ component: Media
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We'll want to put up various signage of our own, even if the venue cover
   the basics. For example, we have our own giant banner which should go

--- a/comp/venue/sound.yaml
+++ b/comp/venue/sound.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
     Speakers and wireless microphones for the judges are required.
 

--- a/comp/venue/transport/main.yaml
+++ b/comp/venue/transport/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Day
 
+area-owner: event-logistics
+
 description: >-
   Many things will need to be moved from various locations to the venue.
 

--- a/comp/venue/transport/prepare.yaml
+++ b/comp/venue/transport/prepare.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   The things that we are taking to the competition needs to be prepared for
   transportation. Most of the things we need are in storage, however some

--- a/comp/venue/transport/return.yaml
+++ b/comp/venue/transport/return.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: event-logistics
+
 description: >-
   Equipment that came from storage for the competition needs to return
   there after the competition.

--- a/comp/venue/transport/van.yaml
+++ b/comp/venue/transport/van.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-
   We need a van (probably from Thursday to Monday inclusive) to transport all
   the necessary equipment around.

--- a/comp/venue/transport/work-out.yaml
+++ b/comp/venue/transport/work-out.yaml
@@ -6,4 +6,6 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: event-logistics
+
 description: >-

--- a/comp/volunteers/blue-shirts.yaml
+++ b/comp/volunteers/blue-shirts.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     We may need more.

--- a/comp/volunteers/brief-volunteers.yaml
+++ b/comp/volunteers/brief-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   The volunteers need to know:
     - Key Roles & Point of Contacts

--- a/comp/volunteers/comms-training.yaml
+++ b/comp/volunteers/comms-training.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   All volunteers will need to have a basic understanding of what communications
   mechanisms we're using and who to contact in various scenarios.

--- a/comp/volunteers/experts-list.yaml
+++ b/comp/volunteers/experts-list.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     While helpdesk is the primary point of call for teams who need help,
     we also need a way for those manning it to escalate their request

--- a/comp/volunteers/hotels-and-travel.yaml
+++ b/comp/volunteers/hotels-and-travel.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     It's important that volunteers are able to get to the competition,
     therefore hotels and other travel arrangements need to be organised.

--- a/comp/volunteers/information.yaml
+++ b/comp/volunteers/information.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   We should email all the volunteers with information about where to go
   on the day, parking, who to contact, and any other info we need to

--- a/comp/volunteers/main.yaml
+++ b/comp/volunteers/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     Root ticket for the subtree relating to volunteer items
     at the competition.

--- a/comp/volunteers/marshals-briefing.yaml
+++ b/comp/volunteers/marshals-briefing.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   The marshals need to know:
   * what the rules are

--- a/comp/volunteers/marshals-training.yaml
+++ b/comp/volunteers/marshals-training.yaml
@@ -6,6 +6,8 @@ component: Arena
 
 milestone: $SRYYYY Competition Day
 
+area-owner: game
+
 description: >-
   The marshals should have a chance to run through the process
   of running a competition match sequence.

--- a/comp/volunteers/name-badges.yaml
+++ b/comp/volunteers/name-badges.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     Name badges should be printed for all volunteers we know will be there.  We
     should also have blank badges for those we don't expect.

--- a/comp/volunteers/plan-reimbursement.yaml
+++ b/comp/volunteers/plan-reimbursement.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   After the competition we will need to reimburse volunteers for various
   things. We need to plan (and annouce) what things are eligible for

--- a/comp/volunteers/recruit.yaml
+++ b/comp/volunteers/recruit.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   We need to publicise the date and location of the competition to all
   volunteers and solicit their help, both in preparing for the

--- a/comp/volunteers/refreshment-delivery.yaml
+++ b/comp/volunteers/refreshment-delivery.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     Many volunteers are in a single place and cannot move because
     they are continuously active for a long duration (marshall, judges).

--- a/comp/volunteers/refreshments.yaml
+++ b/comp/volunteers/refreshments.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   We should have some refreshments for the volunteers at the competition.
   At a minimum this will include water and cups being available at all times

--- a/comp/volunteers/reimbursement.yaml
+++ b/comp/volunteers/reimbursement.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: volunteer-coordination
+
 description: >-
   We need to reimburse volunteers for all the things. This task exists
   mostly as a placeholder, the treasurer will of course be handling this

--- a/comp/volunteers/saturday-meal.yaml
+++ b/comp/volunteers/saturday-meal.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
   We typically go out on the Saturday evening as volunteers to relax and
   share a meal together. This is normally organised centrally, though

--- a/comp/volunteers/schedule.yaml
+++ b/comp/volunteers/schedule.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to work out how many people we need doing each role and then come up
     with a timetable which shows who is doing which role when.

--- a/comp/website/directions.yaml
+++ b/comp/website/directions.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   To make things easier for teams, we should publish a map and some
   directions to the venue on the website.

--- a/comp/website/livestream.yaml
+++ b/comp/website/livestream.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The live stream needs to be linked or embedded from the website.
 

--- a/comp/website/main.yaml
+++ b/comp/website/main.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   There are website alterations to be made to enable its use live at the
   competition.

--- a/comp/website/public-compbox.yaml
+++ b/comp/website/public-compbox.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
     The competition software has state about the competition which is used
     to drive the live displays of scores (etc.) on the website. We need a

--- a/comp/website/schedule-day.yaml
+++ b/comp/website/schedule-day.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   The schedule for the days needs to be published on the website so
   people know what's going on.

--- a/comp/website/switch-to-live-mode.yaml
+++ b/comp/website/switch-to-live-mode.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition Day
 
+area-owner: media-press
+
 description: >-
   Change the website proxy to use the competition live homepage instead of the
   normal one. This normally happens on the morning of the competition.

--- a/comp/website/switch-to-normal-mode.yaml
+++ b/comp/website/switch-to-normal-mode.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: media-press
+
 description: >-
   Change the website proxy back to using the normal website homepage instead of
   the competition live one. This normally happens on the morning following the

--- a/comp/welcome.yaml
+++ b/comp/welcome.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: production
+
 description: >-
   This ticket exists mainly to ensure that things are announced to the
   competitors.

--- a/comp/whiteboard.yaml
+++ b/comp/whiteboard.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: game
+
 description: >-
   Whiteboards are useful for potentially many things, and particularly
   for organising tinker time.

--- a/comp/wrap-up-email.yaml
+++ b/comp/wrap-up-email.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
+area-owner: media-press
+
 description: >-
   This would cover things like:
 

--- a/comp/wristbands/design.yaml
+++ b/comp/wristbands/design.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
   We need to design some wristbands for the competition.

--- a/comp/wristbands/order.yaml
+++ b/comp/wristbands/order.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Competition
 
+area-owner: media-press
+
 description: >-
     We need to order wristbands. The order should include the hire of a crimping
     tool if that applies to the kind of wristbands being ordered.

--- a/kickstart/advertise-volunteers.yaml
+++ b/kickstart/advertise-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to advertise the existence of the kickstart to people who might want
     to help run it.

--- a/kickstart/allocate-tlas.yaml
+++ b/kickstart/allocate-tlas.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: teams
+
 description: >-
     Once we've decided which teams are getting places we need to assign them
     their TLAs.

--- a/kickstart/appoint-safeguarding-officers.yaml
+++ b/kickstart/appoint-safeguarding-officers.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: health-safety
+
 description: >-
     Safeguarding officers need to be appointed, by the Safeguarding Lead, as per the safeguarding policy.

--- a/kickstart/confirm-teams.yaml
+++ b/kickstart/confirm-teams.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: teams
+
 description: >-
     We need to inform the teams who have places and invite them to the Kickstart
     venue most suitable for them.

--- a/kickstart/decide-presenters.yaml
+++ b/kickstart/decide-presenters.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: production
+
 description: >-
     The presentation needs to be given at each venue, so will be presented by
     multiple people. It's recommended the person who creates the presentation be one of the people to

--- a/kickstart/kit/allocate.yaml
+++ b/kickstart/kit/allocate.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     Teams will want kits at Kickstart so we need to know which kits to
     give to each team.

--- a/kickstart/kit/fix.yaml
+++ b/kickstart/kit/fix.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     We need to have confidence that the kits we'll hand out at the $SRYYYY
     Kickstart are going to work for the teams. Once tested they may need

--- a/kickstart/kit/main.yaml
+++ b/kickstart/kit/main.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     We need to have kits to hand out at the $SRYYYY Kickstart.
 

--- a/kickstart/kit/ship-courier.yaml
+++ b/kickstart/kit/ship-courier.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     Teams unable to make it to a Kickstart need their kits couriering to
     them.

--- a/kickstart/kit/ship-kickstarts.yaml
+++ b/kickstart/kit/ship-kickstarts.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     Teams will want kits at Kickstart so we need to ship the relevant kits
     to each of the Kickstart venues.

--- a/kickstart/kit/ship-overseas.yaml
+++ b/kickstart/kit/ship-overseas.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     Teams overseas need their kits shipped to them. This has mostly been
     the German teams in the past few years, which have been shipped together

--- a/kickstart/kit/test.yaml
+++ b/kickstart/kit/test.yaml
@@ -6,6 +6,8 @@ component: Kit
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     We need to have confidence that the kits we'll hand out at the $SRYYYY
     Kickstart are going to work for the teams.

--- a/kickstart/kit/update-disclaimer-forms.yaml
+++ b/kickstart/kit/update-disclaimer-forms.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     As the kits contain valuable and potentially dangerous components, many of
     which are not CE marked, we normally ask the team leaders to sign a form

--- a/kickstart/main.yaml
+++ b/kickstart/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: committee
+
 description: >-
     We need to have the $SRYYYY Kickstarts.
 

--- a/kickstart/markers.yaml
+++ b/kickstart/markers.yaml
@@ -6,6 +6,8 @@ component: Rules
 
 milestone: $SRYYYY Kickstart
 
+area-owner: game
+
 description: >-
     We need to generate the fiducial markers used for the $SRYYYY game
     and add them to https://github.com/srobo/game-markers.

--- a/kickstart/microgames.yaml
+++ b/kickstart/microgames.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     At Kickstart we usually have the teams perform some introductory tasks to
     get them familiar with the kit and to establish that they can safely charge

--- a/kickstart/prepare-news-afterwards.yaml
+++ b/kickstart/prepare-news-afterwards.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Kickstart
 
+area-owner: media-press
+
 description: >-
     After the kickstart we want to have a news article which describes how the
     event went and continues to build up the excitement around the comptition.

--- a/kickstart/print-disclaimer-forms.yaml
+++ b/kickstart/print-disclaimer-forms.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     As the kits contain valuable and potentially dangerous components, many of
     which are not CE marked, we normally ask the team leaders to sign a form

--- a/kickstart/publish-news-afterwards.yaml
+++ b/kickstart/publish-news-afterwards.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Kickstart
 
+area-owner: media-press
+
 description: >-
     After the kickstart we want to have a news article which describes how the
     event went and continues to build up the excitement around the comptition.

--- a/kickstart/remind-teams.yaml
+++ b/kickstart/remind-teams.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: teams
+
 description: |
     We need to remind team leaders that the kickstart is happening, communicate
     the final details and encourage them to prepare for it on their end.

--- a/kickstart/remind-volunteers.yaml
+++ b/kickstart/remind-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to remind volunteers that the kickstart is happening and communicate
     the final details: who is doing what, at what venue, what time to arrive, etc.

--- a/kickstart/rules/decide-game.yaml
+++ b/kickstart/rules/decide-game.yaml
@@ -6,6 +6,8 @@ component: Rules
 
 milestone: $SRYYYY Kickstart
 
+area-owner: game
+
 description: >-
     The $SRYYYY game will be different than the previous year's, so we
     need to decide what it will be.

--- a/kickstart/rules/write.yaml
+++ b/kickstart/rules/write.yaml
@@ -6,6 +6,8 @@ component: Rules
 
 milestone: $SRYYYY Kickstart
 
+area-owner: game
+
 description: >-
     We need to have a game to play in $SRYYYY. It will be different than
     the previous year's, so the rules need updating.

--- a/kickstart/send-disclaimer-forms.yaml
+++ b/kickstart/send-disclaimer-forms.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     As the kits contain valuable and potentially dangerous components, many of
     which are not CE marked, we normally ask the team leaders to sign a form

--- a/kickstart/services/forums.yaml
+++ b/kickstart/services/forums.yaml
@@ -6,6 +6,8 @@ component: sysadmin
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     In order to allow the competitors to chat to each other and request help
     from mentors, we setup forums each year. These are typically an instance

--- a/kickstart/services/ide.yaml
+++ b/kickstart/services/ide.yaml
@@ -6,6 +6,8 @@ component: sysadmin
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     In order to enable the competitors to program their robots, we provide a
     hosted IDE for them to work in.

--- a/kickstart/services/main.yaml
+++ b/kickstart/services/main.yaml
@@ -6,6 +6,8 @@ component: sysadmin
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     We provide a hosted IDE and online forums to the teams to use during the
     year. Typically the microgames at Kickstart get the competitors using these,

--- a/kickstart/services/user-accounts/mentors.yaml
+++ b/kickstart/services/user-accounts/mentors.yaml
@@ -6,6 +6,8 @@ component: sysadmin
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     In order to allow mentors to use the various hosted services we provide, in
     order for them to help competitors, we need to give them user accounts.

--- a/kickstart/services/user-accounts/team-leaders.yaml
+++ b/kickstart/services/user-accounts/team-leaders.yaml
@@ -6,6 +6,8 @@ component: sysadmin
 
 milestone: $SRYYYY Kickstart
 
+area-owner: mentoring
+
 description: >-
     In order to allow the competitors to use the various hosted services we
     provide, we need to give them user accounts.

--- a/kickstart/signups-volunteers.yaml
+++ b/kickstart/signups-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to get potential volunteers to sign up to help organise the
     kickstart.

--- a/kickstart/update-api.yaml
+++ b/kickstart/update-api.yaml
@@ -6,6 +6,8 @@ component: pyenv
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
      The `sr.robot3` API needs updating to contain the marker details for
      the $SRYYYY game.

--- a/kickstart/update-dummy-api.yaml
+++ b/kickstart/update-dummy-api.yaml
@@ -6,6 +6,8 @@ component: pyenv
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     The [dummy API](https://github.com/srobo/pyenv-dummy) needs
     updating to contain the marker details for the $SRYYYY game.

--- a/kickstart/update-simulator.yaml
+++ b/kickstart/update-simulator.yaml
@@ -6,6 +6,8 @@ component: Rules
 
 milestone: $SRYYYY Kickstart
 
+area-owner: simulator
+
 description: >-
     The $SRYYYY game will be different to that for the previous year,
     so the arena template in the simulator will need updating.

--- a/kickstart/venues.yaml
+++ b/kickstart/venues.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: event-logistics
+
 description: >-
     In order to have the $SRYYYY Kickstarts we need venues to have it in.
 

--- a/kickstart/website/archive-previous-rules.yaml
+++ b/kickstart/website/archive-previous-rules.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Kickstart
 
+area-owner: game
+
 description: >-
     Move the rules from the [rules](https://studentrobotics.org/docs/rules) page
     to the [game archive](https://studentrobotics.org/docs/rules/archive) in the

--- a/kickstart/website/docs.yaml
+++ b/kickstart/website/docs.yaml
@@ -6,6 +6,8 @@ component: Docs
 
 milestone: $SRYYYY Kickstart
 
+area-owner: kit
+
 description: >-
     The docs will need updating to match the new API for the $SRYYYY API and
     game, specifically https://studentrobotics.org/docs/programming/sr/vision/

--- a/kickstart/website/main.yaml
+++ b/kickstart/website/main.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Kickstart
 
+area-owner: media-press
+
 description: >-
     The website will need updating for $SRYYYY.
 

--- a/kickstart/website/publish-rules.yaml
+++ b/kickstart/website/publish-rules.yaml
@@ -6,6 +6,8 @@ component: Website
 
 milestone: $SRYYYY Kickstart
 
+area-owner: game
+
 description: >-
     These need building and the website patching.
     The [rules](https://studentrobotics.org/docs/rules) page will need updating

--- a/kickstart/write-presentation.yaml
+++ b/kickstart/write-presentation.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Kickstart
 
+area-owner: production
+
 description: |-
     Kickstart events require a presentation to go through what student robotics
     is, what the competition cycle looks like, and details of the game.

--- a/pre/advertise-teams.yaml
+++ b/pre/advertise-teams.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: teams
+
 description: >-
     We need to advertise the existence of the competition programme to people
     who might want to take part.

--- a/pre/advertise-volunteers.yaml
+++ b/pre/advertise-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to advertise the existence of the competition programme to people
     who might want to help run it.

--- a/pre/budget.yaml
+++ b/pre/budget.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: committee
+
 description: >-
     We need to prepare a budget for the $SRYYYY Competition Programme.

--- a/pre/main.yaml
+++ b/pre/main.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: committee
+
 description: >-
     We need to prepare for the $SRYYYY Competition Programme.
 

--- a/pre/signups-teams.yaml
+++ b/pre/signups-teams.yaml
@@ -6,5 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: teams
+
 description: >-
     We need to get potential teams to sign up to take part in the competition.

--- a/pre/signups-volunteers.yaml
+++ b/pre/signups-volunteers.yaml
@@ -6,6 +6,8 @@ component: Competition
 
 milestone: $SRYYYY Preparation
 
+area-owner: volunteer-coordination
+
 description: >-
     We need to get potential volunteers to sign up to help organise the
     competition programme.

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -163,6 +163,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
     )
 
+    parser.add_argument(
+        '--area-owners',
+        help="Include area owners in the generated tickets",
+        action='store_true',
+    )
+    parser.add_argument(
+        '--components',
+        help="Include components in the generated tickets",
+        action='store_true',
+    )
+
     return parser.parse_args()
 
 
@@ -170,7 +181,11 @@ def main(arguments: argparse.Namespace) -> None:
     if arguments.trac_root is not None:
         backend: 'Backend' = RealTracBackend(arguments.trac_root)
     elif arguments.github_repo is not None:
-        backend = GitHubBackend(arguments.github_repo)
+        backend = GitHubBackend(
+            arguments.github_repo,
+            include_area_owners=arguments.area_owners,
+            include_components=arguments.components,
+        )
     else:
         backend = FakeTracBackend()
 

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -30,6 +30,21 @@ COMPONENTS = (
     'Website',
 )
 
+AREA_OWNERS = (
+    'committee',
+    'health-safety',
+    'media-press',
+    'teams',
+    'mentoring',
+    'kit',
+    'event-logistics',
+    'livestream',
+    'production',
+    'game',
+    'volunteer-coordination',
+    'simulator',
+)
+
 
 def process(element_name: str, *, year: str, handle_dep: Callable[[str], int]) -> Ticket:
     """
@@ -64,6 +79,10 @@ def process(element_name: str, *, year: str, handle_dep: Callable[[str], int]) -
     if component not in COMPONENTS:
         raise RuntimeError(f"{path} has an unknown component: {component}")
 
+    area_owner = raw_elements.get('area-owner')
+    if area_owner not in AREA_OWNERS:
+        raise RuntimeError(f"{path} has an unknown area owner: {area_owner}")
+
     milestone = raw_elements.get('milestone')
     dependencies = raw_elements.get('dependencies', ())
 
@@ -75,6 +94,7 @@ def process(element_name: str, *, year: str, handle_dep: Callable[[str], int]) -
         priority=priority,
         milestone=milestone,
         original_name=element_name,
+        area_owner=area_owner,
         description=description,
         dependencies=computed_dependencies,
     )

--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -151,6 +151,20 @@ class GitHubBackend:
         'blocker': 'I: Must Have',
     }
 
+    AREA_OWNER_MAPPING: Dict[str, str] = {
+        'committee': 'AO: Committee',
+        'health-safety': 'AO: Health & Safety',
+        'media-press': 'AO: Media & Press',
+        'teams': 'AO: Teams',
+        'mentoring': 'AO: Mentoring',
+        'kit': 'AO: Kit',
+        'event-logistics': 'AO: Event Logistics',
+        'game': 'AO: Game',
+        'production': 'AO: Production',
+        'simulator': 'AO: Simulator',
+        'livestream': 'AO: Livestream',
+    }
+
     def __init__(self, repo_name: str) -> None:
         self.github = github.Github(get_github_credential())
         self.repo = self.github.get_repo(repo_name)
@@ -169,6 +183,9 @@ class GitHubBackend:
             }
             self._component_priority_mapping = {
                 k: labels[v] for k, v in self.COMPONENT_PRIORITY_MAPPING.items()
+            }
+            self._area_owner_mapping = {
+                k: labels[v] for k, v in self.AREA_OWNER_MAPPING.items()
             }
         except KeyError as e:
             raise ValueError(
@@ -213,6 +230,7 @@ class GitHubBackend:
     def labels(self, ticket: Ticket) -> List[github.Label.Label]:
         labels = [self._component_priority_mapping[ticket.priority]]
         labels += self._component_label_mapping[ticket.component]
+        labels.append(self._area_owner_mapping[ticket.area_owner])
         return labels
 
     def submit(self, ticket: Ticket) -> int:

--- a/scripts/ticket_type.py
+++ b/scripts/ticket_type.py
@@ -7,5 +7,6 @@ class Ticket(NamedTuple):
     component: str
     original_name: str
     milestone: str
+    area_owner: str
     description: str
     dependencies: List[int]

--- a/test/cook.yaml
+++ b/test/cook.yaml
@@ -6,6 +6,8 @@ component: Tall Ship
 
 milestone: $SRYYYY Competition
 
+area-owner: committee
+
 description: >-
   We should cook the bees.
 

--- a/test/get.yaml
+++ b/test/get.yaml
@@ -6,5 +6,7 @@ component: Tall Ship
 
 milestone: $SRYYYY Competition
 
+area-owner: committee
+
 description: >-
   Bees need purchasing for consumption.

--- a/test/main.yaml
+++ b/test/main.yaml
@@ -6,6 +6,8 @@ component: Tall Ship
 
 milestone: $SRYYYY Competition
 
+area-owner: committee
+
 description: >-
   We should consume many bees.
 


### PR DESCRIPTION
The recurring tasks describe an operational concept which has diverged somewhat from how we do things, but it's not a different world.

This PR adds the mapping onto current area owners to all tickets.