### PR TITLE
Adding HTML comments breaks Github's new tasklists

### DIFF
--- a/scripts/import_backends.py
+++ b/scripts/import_backends.py
@@ -245,7 +245,11 @@ class GitHubBackend:
                 ''').format(
                     # Format separately so we don't have bad interactions with
                     # the dedent above.
-                    dependencies=dependencies,
+                    dependencies="\n".join(
+                        # GitHub includes the title itself when rendering
+                        f" - [ ] #{dep}"
+                        for dep in sorted(ticket.dependencies)
+                    ),
                 )
 
             else:


### PR DESCRIPTION
The tasklist code:

```
```[tasklist]
### Dependencies
 - [ ] #1336 <!-- Prepare a livestream for the SR2024 Kickstart -->
 - [ ] #1337 <!-- [Meta] SR2024 Kickstart Event -->
```

Produces:
<img width="905" alt="image" src="https://github.com/srobo/recurring-tasks/assets/10937272/e1d6a83f-e6cc-436d-8785-f6d7e815cdf1">
Which doesn't check the checkbox when the task is closed.

---

Removing the HTML codes like:

```
```[tasklist]
### Dependencies
 - [ ] #1336
 - [ ] #1337
```

Produces:
<img width="906" alt="image" src="https://github.com/srobo/recurring-tasks/assets/10937272/b8d553e2-8e7f-47f2-bf63-20d741813a60">
Which properly tracks tasks closing.