### PR TITLE
Move meta task to committee

### DIFF
--- a/comp/cleanup.yaml
+++ b/comp/cleanup.yaml
@@ -6,7 +6,7 @@ component: Competition
 
 milestone: $SRYYYY Competition Cleanup
 
-area-owner: event-logistics
+area-owner: committee
 
 description: >-
   Root ticket for all cleanup related items


### PR DESCRIPTION
Meta tasks contain no actions themselves and exist to handle the dependencies needed for a particular event.

All other meta tasks are owned by the committee, move the one that was missed.