### PR TITLE
Add more subtasks as part of team signup

### DIFF
--- a/kickstart/signup-teams.yaml
+++ b/kickstart/signup-teams.yaml
@@ -49,4 +49,9 @@ description: >-
      - [ ] Select teams for the $SRYYYY Competition Programme
      - [ ] Allocate TLAs for any rookie teams
      - [ ] Collect additional information from selected teams and send disclaimer forms
+     - [ ] Collect disclaimer forms from teams
+     - [ ] Validate information received from teams
+     - [ ] Inform secondary contacts about their role
+     - [ ] Let teams on the waiting list know that they are
+     - [ ] Inform teams who aren't getting a place (nor on the waiting list)
      - [ ] Send final details about Kickstart to team leaders


### PR DESCRIPTION
Things we did in SR2025 which should be done each year:
- https://github.com/srobo/tasks/issues/1464
- https://github.com/srobo/tasks/issues/1466
- https://github.com/srobo/tasks/issues/1467