### PR TITLE
Separate out the teams/volunteers reminder emails for Kickstart

### DIFF
--- a/kickstart/details-teams.yaml
+++ b/kickstart/details-teams.yaml
@@ -1,0 +1,25 @@
+summary: Send teams final details for the $SRYYYY Kickstart
+
+priority: should
+
+component: Competition
+
+milestone: $SRYYYY Kickstart
+
+area-owner: teams
+
+description: >-
+    We should aim to tell them:
+     - The venue for Kickstart
+     - Travel details for the venue (address, parking, etc.)
+     - What time to arrive/when the livestream starts
+     - That their team members should join the Discord server
+
+    Required actions:
+     - [ ] Ensure the final details are on the website
+     - [ ] Send final details about Kickstart to team supervisors
+
+dependencies:
+  - kickstart/discord
+  - kickstart/signup-teams
+  - kickstart/risk-assessments

--- a/kickstart/details-volunteers.yaml
+++ b/kickstart/details-volunteers.yaml
@@ -1,0 +1,24 @@
+summary: Send volunteers details for the $SRYYYY Kickstart
+
+priority: should
+
+component: Competition
+
+milestone: $SRYYYY Kickstart
+
+area-owner: volunteer-coordination
+
+description: >-
+    We should aim to tell them:
+     - The venue for Kickstart
+     - Travel details for the venue (address, parking, etc.)
+     - What time to arrive
+     - That they should join the Discord server
+
+    Required actions:
+     - [ ] Ensure the final details are on the website
+     - [ ] Send final details about Kickstart to volunteers
+
+dependencies:
+  - kickstart/discord
+  - kickstart/signup-volunteers

--- a/kickstart/event.yaml
+++ b/kickstart/event.yaml
@@ -24,6 +24,9 @@ dependencies:
     - kickstart/risk-assessments
     - kickstart/appoint-safeguarding-officers
     - kickstart/budget
+    - kickstart/signup-teams
     - kickstart/signup-volunteers
+    - kickstart/details-teams
+    - kickstart/details-volunteers
     - kickstart/simulator-fixes
     - kickstart/livestream

--- a/kickstart/signup-teams.yaml
+++ b/kickstart/signup-teams.yaml
@@ -54,4 +54,6 @@ description: >-
      - [ ] Inform secondary contacts about their role
      - [ ] Let teams on the waiting list know that they are
      - [ ] Inform teams who aren't getting a place (nor on the waiting list)
-     - [ ] Send final details about Kickstart to team leaders
+
+dependencies:
+  - comp/announce

--- a/kickstart/signup-volunteers.yaml
+++ b/kickstart/signup-volunteers.yaml
@@ -26,4 +26,6 @@ description: >-
     Required actions:
      - [ ] Create a signup form for volunteers
      - [ ] Advertise the signup form to potential volunteers, e.g. on Slack and by email
-     - [ ] Send out reminder email to volunteers with Kickstart details
+
+dependencies:
+  - comp/announce


### PR DESCRIPTION
This decouples getting signups for the year as a whole from sending the reminder emails for the first (public) event of the year. The signup tasks can, should (and likely will) happen long before the Kickstart event, yet the reminder email is something we'll send out only a few days before.

Previously the coupling of these meant that we had tasks which were forced to stay open for a long time, not getting updates, creating confusion and increasing the chances that something would be missed.

This also adds in some overlooked dependencies.

Builds on #103 to avoid conflicts.